### PR TITLE
Make `eaf-open-music-player` behave expectedly

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -35,7 +35,7 @@ class AppBuffer(BrowserBuffer):
     def __init__(self, buffer_id, url, arguments):
         BrowserBuffer.__init__(self, buffer_id, url, arguments, False)
 
-        self.first_file = os.path.expanduser(arguments)
+        self.first_file = os.path.expanduser(url)
         self.panel_background_color = QColor(self.theme_background_color).darker(110).name()
 
         self.load_index_html(__file__)

--- a/eaf-music-player.el
+++ b/eaf-music-player.el
@@ -122,10 +122,10 @@
 (defun eaf-open-music-player (&optional music-file)
   "Open EAF music player."
   (interactive)
-  (eaf-open "eaf-music-player"
+  (eaf-open (read-file-name "Open music: " (or music-file
+                                               eaf-music-default-file))
             "music-player"
-            (read-file-name "Open music: " (or music-file
-                                               eaf-music-default-file))))
+            ))
 
 (add-to-list 'eaf-app-extensions-alist '("music-player" . eaf-music-extension-list))
 (add-to-list 'eaf-app-binding-alist '("music-player" . eaf-music-player-keybinding))


### PR DESCRIPTION
I guess what I fixed(this commit) has a terminology In the field of
programming, but I am not familiar with that, so I describe this in my
way.

* Bug description:

If I am in a dired buffer or eaf-file-manager and I want to open a
file named "a.mp3", it will open eaf-music-player without "a.mp3"

* After fixes:

If I am in a dired buffer or eaf-file-manager and I want to open a
file named "a.mp3", it will open eaf-music-player with "a.mp3"