### PR TITLE
Update dependencies.json: Altered Gentoo DepPkg

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -3,7 +3,7 @@
     "taglib"
   ],
   "emerge": [
-    "media-libs/libtaginfo"
+    "media-libs/taglib"
   ],
   "apt": [
     "libtag1-dev"


### PR DESCRIPTION
Package: `media-libs/libtaginfo` was removed from the official Gentoo Repo since Apr 26, 2022, 
due to ``Long abandoned upstreams, segfaults, bunch of tests fail''. 
Attempting to install this package using `emerge` would result in failing to install, and failing to run `eaf-music-player` .

Source1: [Mail Archive for gentoo-dev](https://www.mail-archive.com/gentoo-dev@lists.gentoo.org/msg94742.html)
Source2: [media-libs/taglib package at Gentoo Repo](https://packages.gentoo.org/packages/media-libs/taglib)