### PR TITLE
Replace '/' in the song title and artists name with '_' .

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -231,8 +231,8 @@ class FetchCover(QThread):
 
         self.track = track
         self.cover_cache_dir = cover_cache_dir
-        self.artist = artist
-        self.title = title
+        self.artist = artist.replace('/', '_')
+        self.title = title.replace('/', '_')
 
     def run(self):
         if not os.path.exists(self.cover_cache_dir):


### PR DESCRIPTION
When a song has multiple artists as its authors, the '/' in the artist name can cause directory access errors, for example, "Something Just Like This" by Coldplay/The Chainsmokers.